### PR TITLE
Make literals more readable with underscores

### DIFF
--- a/src/l1d.rs
+++ b/src/l1d.rs
@@ -9,7 +9,7 @@ pub fn measure_l1d() -> Result<usize, ()> {
     let mut counter = 4;
     let mut deduced_cache_size = counter;
     let mut previous_delta = 0;
-    let mut previous_diff = 1000000;
+    let mut previous_diff = 1_000_000;
 
     loop {
         if counter > 256 {
@@ -18,11 +18,11 @@ pub fn measure_l1d() -> Result<usize, ()> {
 
         let stride = counter;
         let starttime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let start_ns = (starttime.tv_sec() * 1000000000 + starttime.tv_nsec()) / 1000;
+        let start_ns = (starttime.tv_sec() * 1_000_000_000 + starttime.tv_nsec()) / 1000;
         let mut pos = 0;
 
         loop {
-            buffer[pos * (stride * 2) & STEPS_N - 1] = buffer[pos * (stride * 2) & STEPS_N - 1].wrapping_add(1);
+            buffer[(pos * (stride * 2)) & (STEPS_N - 1)] = buffer[(pos * (stride * 2)) & (STEPS_N - 1)].wrapping_add(1);
 
             pos += 1;
             if pos > STEPS_N {
@@ -31,7 +31,7 @@ pub fn measure_l1d() -> Result<usize, ()> {
         }
 
         let endtime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let end_ns = (endtime.tv_sec() * 1000000000 + endtime.tv_nsec()) / 1000;
+        let end_ns = (endtime.tv_sec() * 1_000_000_000 + endtime.tv_nsec()) / 1000;
         let delta = end_ns - start_ns;
 
         if previous_delta > 0 {
@@ -46,5 +46,5 @@ pub fn measure_l1d() -> Result<usize, ()> {
         previous_delta = delta;
     }
 
-    return Ok(deduced_cache_size / 2);
+    Ok(deduced_cache_size / 2)
 }

--- a/src/pipecopy.rs
+++ b/src/pipecopy.rs
@@ -16,15 +16,15 @@ impl Test for PipeCopyTest {
         let mut buf = vec![0u8; 1024];
 
         let starttime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let start_ns = (starttime.tv_sec() * 1000000000 + starttime.tv_nsec()) / 1000;
+        let start_ns = (starttime.tv_sec() * 1_000_000_000 + starttime.tv_nsec()) / 1000;
 
-        for _ in 0..1024768 {
+        for _ in 0..1_024_768 {
             writer.write_all(&buf).expect("failed to write to pipe");
             reader.read_exact(&mut buf).expect("failed to read from pipe");
         }
 
         let endtime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let end_ns = (endtime.tv_sec() * 1000000000 + endtime.tv_nsec()) / 1000;
+        let end_ns = (endtime.tv_sec() * 1_000_000_000 + endtime.tv_nsec()) / 1000;
 
         let result = (end_ns - start_ns) as f32;
 

--- a/src/shacrypt.rs
+++ b/src/shacrypt.rs
@@ -15,14 +15,14 @@ impl Test for ShaCryptVerifyTest {
 
     fn run(&self, _paras: TestParameters) -> Result<f32, ()> {
         let starttime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let start_ns = (starttime.tv_sec() * 1000000000 + starttime.tv_nsec()) / 1000;
+        let start_ns = (starttime.tv_sec() * 1_000_000_000 + starttime.tv_nsec()) / 1000;
 
         for _ in 0..1000 {
             let _ = sha512_check(ANSWER, VERIFY_HASH);
         }
 
         let endtime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let end_ns = (endtime.tv_sec() * 1000000000 + endtime.tv_nsec()) / 1000;
+        let end_ns = (endtime.tv_sec() * 1_000_000_000 + endtime.tv_nsec()) / 1000;
 
         let result = (end_ns - start_ns) as f32;
 

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -33,14 +33,14 @@ impl Test for SieveTest {
 
     fn run(&self, _paras: TestParameters) -> Result<f32, ()> {
         let starttime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let start_ns = (starttime.tv_sec() * 1000000000 + starttime.tv_nsec()) / 1000;
+        let start_ns = (starttime.tv_sec() * 1_000_000_000 + starttime.tv_nsec()) / 1000;
 
         for _ in 0..20 {
-            sieve(10000000);
+            sieve(10_000_000);
         }
 
         let endtime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let end_ns = (endtime.tv_sec() * 1000000000 + endtime.tv_nsec()) / 1000;
+        let end_ns = (endtime.tv_sec() * 1_000_000_000 + endtime.tv_nsec()) / 1000;
 
         let result = (end_ns - start_ns) as f32;
 

--- a/src/socketpaircopy.rs
+++ b/src/socketpaircopy.rs
@@ -16,15 +16,15 @@ impl Test for SocketPairCopyTest {
         let mut buf = vec![0u8; 1024];
 
         let starttime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let start_ns = (starttime.tv_sec() * 1000000000 + starttime.tv_nsec()) / 1000;
+        let start_ns = (starttime.tv_sec() * 1_000_000_000 + starttime.tv_nsec()) / 1000;
 
-        for _ in 0..1024768 {
+        for _ in 0..1_024_768 {
             writer.write_all(&buf).expect("failed to write to socket");
             reader.read_exact(&mut buf).expect("failed to read from socket");
         }
 
         let endtime = clock_gettime(ClockId::CLOCK_REALTIME).expect("realtime clock value not found");
-        let end_ns = (endtime.tv_sec() * 1000000000 + endtime.tv_nsec()) / 1000;
+        let end_ns = (endtime.tv_sec() * 1_000_000_000 + endtime.tv_nsec()) / 1000;
 
         let result = (end_ns - start_ns) as f32;
 


### PR DESCRIPTION
This was generated with:
```sh
cargo clippy --fix -- -W clippy::unreadable_literal
```
and makes the code slightly easier to read. :)